### PR TITLE
Switch to shutil which implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ a device (e.g. L0s, L0sL1 or L1).
 ### NixOS - Run once
 
 ```bash
-sudo nix run github:notthebee/AutoASPM
+sudo nix run git+https://git.notthebe.ee/notthebee/AutoASPM
 ```
 
 ### NixOS - Install permanently
@@ -26,11 +26,10 @@ sudo nix run github:notthebee/AutoASPM
 ```nix
 {
   inputs.autoaspm = {
-    url = "github:notthebee/AutoASPM?shallow=true";
+    url = "git+https://git.notthebe.ee/notthebee/AutoASPM";
     # NOTE: optionally your flake's `nixpkgs`
     # inputs.nixpkgs.follows = "nixpkgs";
   };
-
   # ...
 }
 ```

--- a/pkgs/autoaspm.py
+++ b/pkgs/autoaspm.py
@@ -9,6 +9,7 @@ import subprocess
 import os
 import platform
 from enum import Enum
+from shutil import which
 
 class ASPM(Enum):
     DISABLED = 0b00
@@ -22,11 +23,9 @@ def run_prerequisites():
         raise OSError("This script only runs on Linux-based systems")
     if not os.environ.get("SUDO_UID") and os.geteuid() != 0:
         raise PermissionError("This script needs root privileges to run")
-    lspci_detected = subprocess.run(["which", "lspci"], stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
-    if lspci_detected.returncode > 0:
+    if which("lspci") is None:
         raise Exception("lspci not detected. Please install pciutils")
-    lspci_detected = subprocess.run(["which", "setpci"], stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
-    if lspci_detected.returncode > 0:
+    if which("setpci") is None:
         raise Exception("setpci not detected. Please install pciutils")
 
 


### PR DESCRIPTION
Remove external dependency on `which` and rather use the [python native implementation provided by `shutil`](https://docs.python.org/3.13/library/shutil.html#shutil.which). Thereby it is not necessary to install `which` on your system to run this tool.