### PR TITLE
refactor: touch up package and module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,10 @@
     in
     {
       overlays.default = import ./overlay.nix;
-      nixosModules.autoaspm = { config, lib, pkgs, ... }: import ./modules/autoaspm.nix { inherit config lib pkgs; autoaspm = self.packages.${pkgs.system}.autoaspm; };
-      nixosModules.default = self.nixosModules.autoaspm;
+      nixosModules = {
+        autoaspm = import ./modules/autoaspm.nix { inherit self; };
+        default = self.nixosModules.autoaspm;
+      };
       packages = eachSystem (system: {
         default = self.packages.${system}.autoaspm;
         autoaspm = nixpkgs.legacyPackages.${system}.callPackage ./pkgs/autoaspm.nix { };

--- a/modules/autoaspm.nix
+++ b/modules/autoaspm.nix
@@ -1,8 +1,12 @@
+# NOTE: arguments passed from the flake directly
+{
+  self,
+  ...
+}:
 {
   config,
   pkgs,
   lib,
-  autoaspm,
   ...
 }:
 let
@@ -11,24 +15,20 @@ in
 {
   options.services.autoaspm = {
     enable = lib.mkEnableOption "Automatically activate ASPM on all supported devices";
+    package = lib.mkPackageOption self.packages.${pkgs.stdenv.hostPlatform.system} "autoaspm" { };
   };
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [
-      autoaspm
+      cfg.package
     ];
+
     systemd.services.autoaspm = {
       description = "Automatically activate ASPM on all supported devices";
       wantedBy = [ "multi-user.target" ];
-      path = [
-        pkgs.python313
-        pkgs.which
-        pkgs.pciutils
-        autoaspm
-      ];
       serviceConfig = {
         Type = "oneshot";
-        ExecStart = "${lib.getExe pkgs.python313} ${autoaspm}/bin/autoaspm";
+        ExecStart = "${lib.getExe cfg.package}";
       };
     };
   };

--- a/pkgs/autoaspm.nix
+++ b/pkgs/autoaspm.nix
@@ -1,14 +1,43 @@
 {
-  pkgs,
+  lib,
+  stdenv,
+  makeWrapper,
+  pciutils,
+  which,
+  python3,
 }:
-pkgs.stdenv.mkDerivation {
-  name = "autoaspm";
+
+stdenv.mkDerivation {
   pname = "autoaspm";
-  propagatedBuildInputs = [
-    pkgs.pciutils
-    pkgs.which
-    pkgs.python3
+  version = "0.1";
+
+  src = ./autoaspm.py;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    pciutils
+    which
   ];
+
   dontUnpack = true;
-  installPhase = "install -Dm755 ${./autoaspm.py} $out/bin/autoaspm";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/libexec/autoaspm/autoaspm.py
+
+    makeWrapper ${python3.interpreter} "$out/bin/autoaspm" \
+      --add-flags "$out/libexec/autoaspm/autoaspm.py" \
+      --prefix PATH : ${lib.makeBinPath [ pciutils which ]}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Automatically enable ASPM on all supported PCIe devices";
+    homepage = "https://github.com/notthebee/AutoASPM";
+    platforms = lib.platforms.linux;
+    mainProgram = "autoaspm";
+  };
 }


### PR DESCRIPTION
- Add a `package` option to the module
- Pass the custom package to the module with `self`
- Refactor package to wrap the script in a `python` call
- Simplify the module (since the package is self-contained now)